### PR TITLE
Add legal notice to interface

### DIFF
--- a/_locales/en/interface.html
+++ b/_locales/en/interface.html
@@ -45,7 +45,7 @@
     <button id='VShelpBtn' class='VSbutton' title='show instructions on new tab'>Help</button>
     </div>
     <br>
-    <p class='VSp'>v 0.5 &nbsp;&#169; F. Ruiz 2023</p>
+    <p class='VSp'>v 0.5 &nbsp;&#169; F. Ruiz 2023 &#8226; The performance of the motion picture is altered from the performance intended by the director or copyright holder of the motion picture.</p>
 </div>
 
 <div class='VStabContent' id='VSsyncTab'>

--- a/_locales/es/interface.html
+++ b/_locales/es/interface.html
@@ -45,7 +45,7 @@
     <button id='VShelpBtn' class='VSbutton' title='mostrar instrucciones en nueva pestaña'>Ayuda</button>
     </div>
     <br>
-    <p class='VSp'>v 0.5 &nbsp;&#169; F. Ruiz 2023</p>
+    <p class='VSp'>v 0.5 &nbsp;&#169; F. Ruiz 2023 &#8226; La representación de la película se altera con respecto a la prevista por el director o el titular de los derechos de autor de la película.</p>
 </div>
 
 <div class='VStabContent' id='VSsyncTab'>

--- a/_locales/fr/interface.html
+++ b/_locales/fr/interface.html
@@ -46,7 +46,7 @@
     <button id='VShelpBtn' class='VSbutton' title='afficher les instructions sur le nouvel onglet'>Aide</button>
     </div>
     <br>
-    <p class='VSp'>v 0.5 &nbsp;&#169; F. Ruiz 2023</p>
+    <p class='VSp'>v 0.5 &nbsp;&#169; F. Ruiz 2023 &#8226; La représentation du film est modifiée par rapport à la représentation prévue par le réalisateur ou le détenteur des droits d'auteur du film.</p>
 </div>
 
 <div class='VStabContent' id='VSsyncTab'>

--- a/_locales/pt/interface.html
+++ b/_locales/pt/interface.html
@@ -45,7 +45,7 @@
     <button id='VShelpBtn' class='VSbutton' title='Mostre as instruções em nova aba'>Ajuda</button>
     </div>
     <br>
-    <p class='VSp'>v 0.5 &nbsp;&#169; F. Ruiz 2023</p>
+    <p class='VSp'>v 0.5 &nbsp;&#169; F. Ruiz 2023 &#8226; A performance do filme é alterada em relação à performance pretendida pelo diretor ou detentor dos direitos autorais do filme.</p>
 </div>
 
 <div class='VStabContent' id='VSsyncTab'>


### PR DESCRIPTION
Adds legal notice to conform with section 3b of the [Family Entertainment and Copyright Act of 2005](https://www.congress.gov/bill/109th-congress/house-bill/357/text). Translations automatically created using [DeepL Translator](https://www.deepl.com/translator), may need to be adjusted. The Portuguese translation is currently in Brazillian Portuguese.